### PR TITLE
Type narrowing metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,7 @@ curl --request POST \
     - This is because Array methods like includes, find, etc, will iterate through each element of
       the array, resulting in O(n) complexity which grows linearly with size
     - On the other hand Set<> has a O(1) constant time lookup - we'll implement as the final commit
+- Last point, and then we should really move on, realistically you would not store these metrics as
+  constants.
+  They would be fetched from a database, so we'd have to sacrifice compile-time checks and only use
+  the run-time check. Branded types could be used if we want to label the validated metrics.

--- a/README.md
+++ b/README.md
@@ -117,3 +117,20 @@ curl --request POST \
 
 - Rereading the scope of the task, there was a particular interest in the data structure used,
   hopefully the plan above is enough to show the approach I would have used!
+
+## Progress outside of interview timeframe (post review)
+
+- Didn't catch the power calculation step :-( if I had caught it, I may have implemented a stricter
+  Metric type (Union) and run time validation via type guard.
+- In a real world situation, especially ingesting data from building services and industrial
+  protocols, perhaps this would introduce brittleness to the system where metrics can be dynamic or
+  open-ended
+    - The lead time implementing this new metric into the code base could lead to data loss.
+      I would store everything that fits the schema of the line...
+    - If `POWER` is a necessary calculation, which it sounds like it is, and we want to allow
+      ingestion of all metrics, we can't validate it on each request because readings are line
+      by line one line does not guarantee the next, so:
+        - Warn or flag when required metrics are missing on the `GET` request
+        - Defer the Power calculation to a scheduled job (e.g. cron) at the end of the day...
+        - Anything else? metrics_metadata table perhaps? Totally forgot to consider sensorId as
+          part of the key! sensorId would be critical in real-world data.

--- a/README.md
+++ b/README.md
@@ -120,17 +120,20 @@ curl --request POST \
 
 ## Progress outside of interview timeframe (post review)
 
+### Strict type checking for the Metric
+
 - Didn't catch the power calculation step :-( if I had caught it, I may have implemented a stricter
   Metric type (Union) and run time validation via type guard.
-- In a real world situation, especially ingesting data from building services and industrial
-  protocols, perhaps this would introduce brittleness to the system where metrics can be dynamic or
-  open-ended
-    - The lead time implementing this new metric into the code base could lead to data loss.
-      I would store everything that fits the schema of the line...
-    - If `POWER` is a necessary calculation, which it sounds like it is, and we want to allow
-      ingestion of all metrics, we can't validate it on each request because readings are line
-      by line one line does not guarantee the next, so:
-        - Warn or flag when required metrics are missing on the `GET` request
-        - Defer the Power calculation to a scheduled job (e.g. cron) at the end of the day...
-        - Anything else? metrics_metadata table perhaps? Totally forgot to consider sensorId as
-          part of the key! sensorId would be critical in real-world data.
+    - In a real world situation, especially ingesting data from building services and industrial
+      protocols, perhaps this would introduce brittleness to the system where metrics can be dynamic
+      or
+      open-ended
+        - The lead time implementing this new metric into the code base could lead to data loss.
+          I would store everything that fits the schema of the line...
+        - If `POWER` is a necessary calculation, which it sounds like it is, and we want to allow
+          ingestion of all metrics, we can't validate it on each request because readings are line
+          by line one line does not guarantee the next, so:
+            - Warn or flag when required metrics are missing on the `GET` request
+            - Defer the Power calculation to a scheduled job (e.g. cron) at the end of the day...
+            - Anything else? metrics_metadata table perhaps? Totally forgot to consider sensorId as
+              part of the key! sensorId would be critical in real-world data.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ curl --request POST \
 - Rereading the scope of the task, there was a particular interest in the data structure used,
   hopefully the plan above is enough to show the approach I would have used!
 
-## Progress outside of interview timeframe (post review)
+## Progress outside interview timeframe (post review)
 
 ### Strict type checking for the Metric
 
@@ -137,3 +137,17 @@ curl --request POST \
             - Defer the Power calculation to a scheduled job (e.g. cron) at the end of the day...
             - Anything else? metrics_metadata table perhaps? Totally forgot to consider sensorId as
               part of the key! sensorId would be critical in real-world data.
+
+#### Post Implementation notes
+
+- I used a type guard to implement runtime validation and compile-time type narrowing.
+- The use of a const read-only array was fine with only two Metrics, and using .find() allowed me to
+  avoid using as (which I did initially with .includes()).
+    - commit: 9cd4ac3f74dc8f7e5ee228ce87ae1343ef3f5778
+- Comment from `simondo92`: How would we validate if that list grows to hundreds of codes?
+    - As discussed with only a few metrics Arrays are fine, but as this list scales Arrays are not
+      optimal..
+    - Instead we should use a Set<> and then use .has() to check for the metric
+    - This is because Array methods like includes, find, etc, will iterate through each element of
+      the array, resulting in O(n) complexity which grows linearly with size
+    - On the other hand Set<> has a O(1) constant time lookup - we'll implement as the final commit

--- a/src/libs/readings-parser.ts
+++ b/src/libs/readings-parser.ts
@@ -49,5 +49,7 @@ function validateAndParse(line: string, row: number): SensorReading {
 }
 
 function isMetricValid(metric: string): metric is ValidMetric {
-  return METRICS.includes(metric as ValidMetric);
+  const idx = METRICS.findIndex(el => el === metric);
+
+  return idx !== -1;
 }

--- a/src/libs/readings-parser.ts
+++ b/src/libs/readings-parser.ts
@@ -31,6 +31,10 @@ function validateAndParse(line: string, row: number): SensorReading {
     throw new Error(`Row: ${row} has time: ${date}  in incorrect format`);
   }
 
+  if (!isMetricValid(name)) {
+    throw new Error(`Row: ${row} has metric ${name} which is not one of allowed: ${METRICS}`);
+  }
+
   const value = Number(valueStr);
 
   if (isNaN(value)) {

--- a/src/libs/readings-parser.ts
+++ b/src/libs/readings-parser.ts
@@ -1,4 +1,4 @@
-import {SensorReading} from "../types/sensors";
+import {METRICS, SensorReading, ValidMetric} from "../types/sensors";
 
 export function parseReadingsPayload(payload: string) {
   const lines = payload.split('\n');
@@ -43,9 +43,6 @@ function validateAndParse(line: string, row: number): SensorReading {
     value
   };
 }
-
-const METRICS = ["VOLTAGE", "CURRENT"] as const;
-type ValidMetric = typeof METRICS[number]
 
 function isMetricValid(metric: string): metric is ValidMetric {
   return METRICS.includes(metric as ValidMetric);

--- a/src/libs/readings-parser.ts
+++ b/src/libs/readings-parser.ts
@@ -1,4 +1,4 @@
-import {SensorReading} from "../repositories/readings.repository";
+import {SensorReading} from "../types/sensors";
 
 export function parseReadingsPayload(payload: string) {
   const lines = payload.split('\n');

--- a/src/libs/readings-parser.ts
+++ b/src/libs/readings-parser.ts
@@ -42,5 +42,11 @@ function validateAndParse(line: string, row: number): SensorReading {
     name,
     value
   };
+}
 
+const METRICS = ["VOLTAGE", "CURRENT"] as const;
+type ValidMetric = typeof METRICS[number]
+
+function isMetricValid(metric: string): metric is ValidMetric {
+  return METRICS.includes(metric as ValidMetric);
 }

--- a/src/libs/readings-parser.ts
+++ b/src/libs/readings-parser.ts
@@ -48,6 +48,8 @@ function validateAndParse(line: string, row: number): SensorReading {
   };
 }
 
+const METRIC_SET = new Set(METRICS);
+
 function isMetricValid(metric: string): metric is ValidMetric {
-  return METRICS.find((el): el is ValidMetric => el === metric) !== undefined;
+  return METRIC_SET.has(metric as ValidMetric); // This has O(1) compared to Array.includes()
 }

--- a/src/libs/readings-parser.ts
+++ b/src/libs/readings-parser.ts
@@ -49,7 +49,5 @@ function validateAndParse(line: string, row: number): SensorReading {
 }
 
 function isMetricValid(metric: string): metric is ValidMetric {
-  const idx = METRICS.findIndex(el => el === metric);
-
-  return idx !== -1;
+  return METRICS.find((el): el is ValidMetric => el === metric) !== undefined;
 }

--- a/src/repositories/readings.repository.ts
+++ b/src/repositories/readings.repository.ts
@@ -1,10 +1,6 @@
 import db from "../database";
+import {SensorReading} from "../types/sensors";
 
-export interface SensorReading {
-  time: string;
-  name: string;
-  value: number;
-}
 
 interface IReadingsRepository {
   getReadings(from: Date, to: Date): Promise<{ success: true, data: SensorReading[] } | {

--- a/src/types/sensors.d.ts
+++ b/src/types/sensors.d.ts
@@ -1,5 +1,9 @@
+const METRICS = ["VOLTAGE", "CURRENT"] as const;
+
+type ValidMetric = typeof METRICS[number];
+
 export interface SensorReading {
   time: string;
-  name: string;
+  name: ValidMetric;
   value: number;
 }

--- a/src/types/sensors.d.ts
+++ b/src/types/sensors.d.ts
@@ -1,5 +1,4 @@
 const METRICS = ["VOLTAGE", "CURRENT"] as const;
-
 type ValidMetric = typeof METRICS[number];
 
 export interface SensorReading {

--- a/src/types/sensors.d.ts
+++ b/src/types/sensors.d.ts
@@ -1,0 +1,5 @@
+export interface SensorReading {
+  time: string;
+  name: string;
+  value: number;
+}


### PR DESCRIPTION
# Type narrowing the metric

- Question from simondo92 about type guards and narrowing the type for the Matric.  
- Again, full notes in the README.md
- This solution assumes you have a list of metrics, in reality you might fetch these from a database.  As a result you may have to sacrifice the compile-time type narrowing, but the runtime type guards would remain the same...

